### PR TITLE
Adds logic to skip over duplicate incidents (same ID)

### DIFF
--- a/firebot.py
+++ b/firebot.py
@@ -121,14 +121,16 @@ def process_wildcad():
         data.append([c.text_content() for c in row.getchildren()])
 
     counter = 0
+    checked_ids = []
 
     for item in data:
         counter = counter + 1
-        if counter > 2:
+        if counter > 2 and item[1] not in checked_ids:
             item_date = item[0].split('/')
             item_date_split = item_date[2].split(' ')
             item_date[2] = item_date_split[0]
             item_date.append(item_date_split[1])
+            checked_ids.append(item[1])
 
             item_dict = {
                 'id': empty_fill(item[1]), # "Inc #" field
@@ -214,7 +216,7 @@ def is_fire(inci_dict):
     Simple algo determines whether the given incident matches our criteria for
     a fire incident
     """
-    ignore_list = ('DAILY STATUS', 'ANF-2234')
+    ignore_list = ('DAILY STATUS')
 
     if(
         (


### PR DESCRIPTION
### Problem
Today ANF dispatch created two separate incidents with the same ID, `ANF-2234`. The result was 2 "changed incident" notifications per run/minute, resulting in 300+ unnecessary messages in the ANF FireBot Telegram channel. There's a first time for everything...
![Screen Shot 2022-07-15 at 9 52 00 PM](https://user-images.githubusercontent.com/5241549/179341247-b1619de7-c000-4176-b14f-89520c41ea9c.png)

### Solution
We are going to simply ignore any incidents with duplicate IDs beyond the first one found in the table (each run). As the incident ID acts as our primary key, and it is the only non-changing field value, it is the obvious choice at this time. In the future we can add a field like `first_seen` to the database and take that into consideration to find suspected duplicates (same incident ID).